### PR TITLE
Propose curlyboi crochet pattern

### DIFF
--- a/Art/stringly_typed.md
+++ b/Art/stringly_typed.md
@@ -1,0 +1,15 @@
+A Stringly-typed Python
+=======================
+
+PyCon AU 2018 had a mascot known as "Curlyboi". When rendered in crochet, he is an example of a stringly-typed Python.
+
+https://twitter.com/freakboy3742/status/1032560930633084929
+
+Proposal:
+---------
+
+* The crochet pattern for curlyboi
+
+* An algorithmic generator for curlybois of arbitrary diameter (The official pattern makes a curlyboi that is approximately the diameter of your thumb, but can be easily expanded to any size).
+
+* (optional) An actual physical curlyboi


### PR DESCRIPTION
PyCon AU 2018 had a mascot known as "Curlyboi". When rendered in crochet, he is an example of a stringly-typed Python.